### PR TITLE
feat: + custom font option

### DIFF
--- a/packages/core/src/plugins/quick-edit/index.tsx
+++ b/packages/core/src/plugins/quick-edit/index.tsx
@@ -76,14 +76,14 @@ export interface QuickEditSubmitPayload {
       .default('ctrl-s')
       .description('save button key shortcut (blank to disable)'),
     'quickEdit.editFont': Schema.union([
-      Schema.const('$preferences').description('Follow MW preferences'),
-      Schema.const('$monospace').description('Monospace'),
-      Schema.const('$sans-serif').description('Sans-serif'),
-      Schema.const('$serif').description('Serif'),
+      Schema.const('preferences').description('Follow MW preferences'),
+      Schema.const('monospace').description('Monospace'),
+      Schema.const('sans-serif').description('Sans-serif'),
+      Schema.const('serif').description('Serif'),
       Schema.string().description('Custom font (same as CSS `font-family` property)').default(''),
     ])
       .description("Font to use in quick edit's textarea")
-      .default('$preferences'),
+      .default('preferences'),
   })
     .description('Quick edit options')
     .extra('category', 'edit')
@@ -488,13 +488,14 @@ export class PluginQuickEdit extends BasePlugin {
     )
   }
 
+  static readonly BUILT_IN_FONT_OPTIONS = ['preferences', 'monospace', 'sans-serif', 'serif']
   async getEditFontOptions() {
     const prefEditFont = (await this.ctx.preferences.get<string>('quickEdit.editFont'))!
-    if (prefEditFont.startsWith('$')) {
+    if (PluginQuickEdit.BUILT_IN_FONT_OPTIONS.includes(prefEditFont)) {
       const editfont =
-        prefEditFont === '$preferences'
+        prefEditFont === 'preferences'
           ? this.ctx.wiki.userOptions?.editfont || 'monospace'
-          : prefEditFont.slice(1)
+          : prefEditFont
       return {
         className: `mw-editfont-${editfont}`,
         fontFamily: '',


### PR DESCRIPTION
## Sourcery 摘要

为快速编辑文本区域启用自定义字体选项，并将字体选项处理集中到一个辅助方法中，同时改进了相关的配置描述。

新功能：
- 允许通过 `quickEdit.editFont` 设置在快速编辑中自定义 CSS `font-family` 字符串

改进：
- 为内置的 `editFont` 选项添加 `$` 前缀，并更新 schema 以包含自定义字符串类型
- 将字体选择逻辑提取到一个新的 `getEditFontOptions` 辅助方法中
- 将计算出的 `fontOptions.className` 和 `style.fontFamily` 应用到快速编辑文本区域
- 优化了针对小修改、点击外部关闭和监视列表偏好的 schema 描述

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

为快速编辑启用自定义字体选项，并将字体处理集中到一个辅助方法中。

新功能：
- 通过 `quickEdit.editFont` 为快速编辑文本区域添加自定义字体系列选项

改进：
- 将字体选项逻辑提取到 `getEditFontOptions` 辅助方法中
- 更新 `editMinor`、`outSideClose`、`watchList` 和 `editFont` 选项的 schema 描述
- 将计算出的 `className` 和内联 `fontFamily` 样式应用到快速编辑文本区域

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

启用基于文件的手动偏好设置同步和快速编辑中的自定义字体，并重构核心数据缓存、UI 组件和偏好设置服务，以提高模块化和样式化能力

新功能：
- 在偏好设置同步插件中添加手动文件导入/导出
- 允许在快速编辑文本区域中使用自定义 CSS `font-family`

改进：
- 将快速编辑字体逻辑提取到 `getEditFontOptions` 中，并应用 `className/style` 有效负载
- 重构 `PluginPrefSync`，使用 `importFromFile` 和 `notifyImportSuccess` 辅助函数统一导入逻辑
- 全面改进 `WikiMetadataService`，以分别缓存 `siteinfo` 和 `userinfo`，具有每种类型独立的 TTL，并使用通用的 `initData/fetch/cache` 方法
- 重新定义 `WikiMetadata` 类型，并更新 `WikiTitleModel` 和 `WikiTitleService` 以使用独立的站点和用户信息结构
- 改进 `PreferencesForm` Vue 组件，采用新的选项卡布局、双重 `initialValue/value` 状态以避免竞态条件，并更新 SCSS
- 扩展 `schemastery-form`，通过 `setPartAttr` 和 `exportparts` 属性导出部件以进行样式化，并改进默认样式变量
- 增强 `PreferencesService`，增加 `setMany` 批量更新功能，改进 `getExportableRecord` 以过滤默认值并对键进行排序，并添加 `prefs` 别名
- 规范化 `IPEStorageManager` 中的 TTL 处理，将非正值视为 `Infinity`，并在 `preferences-ui` 模态管理中添加 `prefsModal` 别名

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable manual file-based preference sync and custom fonts in quick-edit, and refactor core data caching, UI components, and preference services for better modularity and styling

New Features:
- Add manual file import/export in preference sync plugin
- Allow custom CSS font-family in quick-edit textarea

Enhancements:
- Extract quick-edit font logic into getEditFontOptions and apply className/style payload
- Refactor PluginPrefSync to unify import logic with importFromFile and notifyImportSuccess helpers
- Overhaul WikiMetadataService to cache siteinfo and userinfo separately with per-kind TTL and generic initData/fetch/cache methods
- Redefine WikiMetadata types and update WikiTitleModel and WikiTitleService to use separate site and user info structures
- Revamp PreferencesForm Vue component with new tabbar layout, dual initialValue/value state to avoid race conditions, and updated SCSS
- Extend schemastery-form to export parts via setPartAttr and exportparts attribute for styling, and improve default styling variables
- Enhance PreferencesService with setMany bulk update, refined getExportableRecord that filters defaults and sorts keys, and add prefs alias
- Normalize TTL handling in IPEStorageManager to treat non-positive values as Infinity and add prefsModal alias in preferences-ui modal management

</details>

</details>

</details>