### PR TITLE
Update install-gadget.md with site-specific instructions

### DIFF
--- a/docs/.templates/install-gadget.md
+++ b/docs/.templates/install-gadget.md
@@ -39,3 +39,12 @@ document.body.append(
 > 2. `MediaWiki:Gadgets-definition` 中相关的行修改为 `* IPE-NEXT[ResourceLoader|rights=edit,skipcaptcha]|IPE-NEXT.js|IPE-NEXT.css`
 >
 > </details>
+>
+> <details>
+>
+> <summary>部分维基站点的启用/安装方法：</summary>
+>
+> 1. [萌娘百科](https://zh.moegirl.org.cn) ：该站点已经通过小工具（Gadget）预装了本插件。登录站点后，在站点的 [参数设置](https://zh.moegirl.org.cn/Special:%E5%8F%82%E6%95%B0%E8%AE%BE%E7%BD%AE#mw-prefsection-gadgets)-编辑工具 中可直接勾选并启用。
+> 2. [灰机Wiki](https://www.huijiwiki.com/) ：该站大部分站点出于对安全的考虑，禁用了个人JS功能。要在该站点下的分站启用插件，需要在灰机workshop的[Manifest:InPageEdit](https://templatemanager.huijiwiki.com/p/799)页面手动安装零件到分站（需要开发者权限）。安装后在分站中点击头像-偏好设置-小零件勾选并为自己启用。
+>
+> </details>


### PR DESCRIPTION
Added installation instructions for specific wiki sites. (Huijiwiki & Moegirl wiki)

## Sourcery 总结

在小工具安装文档中添加萌娘百科和灰机wiki的站点特定安装指南

文档：
- 添加通过用户偏好设置在萌娘百科上启用小工具的说明
- 添加通过工坊 Manifest 和用户偏好设置在灰机wiki子项目上安装和启用小工具的说明

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add site-specific installation guidance for Moegirl Wiki and HuijiWiki to the gadget installation documentation

Documentation:
- Add instructions for enabling the gadget on Moegirl Wiki via user preferences
- Add instructions for installing and enabling the gadget on HuijiWiki subprojects via the workshop Manifest and user preferences

</details>