### PR TITLE
fix(in-article-links): checks for quick-edit hook to attach reliably

### DIFF
--- a/packages/core/src/plugins/in-article-links/index.tsx
+++ b/packages/core/src/plugins/in-article-links/index.tsx
@@ -148,17 +148,17 @@ export class PluginInArticleLinks extends BasePlugin<{
   }
 
   private onContentReady(callback: ($content: JQuery<HTMLElement>) => void) {
-    if (!window.mw) return
-
     const register = () => {
+      if (!window.mw) return
       window.mw.hook('wikipage.content').add(callback)
       const $content = (window as any).$?.('#mw-content-text')
       if ($content?.length) callback($content)
     }
 
-    if (typeof window.mw.hook === 'function') {
+    if (window.mw && typeof window.mw.hook === 'function') {
       register()
     } else {
+      window.RLQ = window.RLQ || ([] as any)
       window.RLQ.push(['mediawiki.base', register])
     }
   }


### PR DESCRIPTION
A lot of the time InPageEdit.ready fails because mw.hook isn't ready, this pr fixes it by polling it again until it is available.

https://github.com/user-attachments/assets/58cc1f2e-ba47-4971-b79c-f8e1c5178d15

https://github.com/user-attachments/assets/2950f20f-37c6-4bc5-bbcb-f63dbd464d1a

## Sourcery 总结

在触发 InPageEdit.ready 之前轮询 MediaWiki 钩子，以确保快速编辑钩子能够可靠地附加。

错误修复:
- 轮询 mw.hook 的可用性，并重试触发 InPageEdit.ready 直到成功，以防止就绪性故障。

改进:
- 将一次性钩子触发器替换为基于间隔的钩子就绪性检查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

确保文章内快速编辑行为能通过 MediaWiki 页面内容钩子可靠初始化。

Bug 修复：
- 通过将钩子注册延后到 MediaWiki 的 `wikipage.content` 钩子可用时，避免在 `InPageEdit.ready` 中发生失败。

增强功能：
- 引入一个共享的“内容就绪”辅助工具，用于注册 `wikipage.content` 钩子，并在内容已存在时立即调用回调函数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure in-article quick edit behavior initializes reliably with MediaWiki page content hooks.

Bug Fixes:
- Prevent failures in InPageEdit.ready by deferring hook registration until MediaWiki's wikipage.content hook is available.

Enhancements:
- Introduce a shared content-ready helper that registers the wikipage.content hook and immediately invokes the callback if content is already present.

</details>

</details>