### PR TITLE
fix: should throw error when api returns error with http 200 (close #13)

### DIFF
--- a/packages/core/src/models/WikiPage/index.ts
+++ b/packages/core/src/models/WikiPage/index.ts
@@ -244,8 +244,8 @@ export function createWikiPageModel(api: MediaWikiApi): WikiPageConstructor {
       } else {
         /**
          * This situation is rare, but it may happen.
-         * In most cases, failed edit will return a MediaWikiApiError { "error": { "code": "editconflict", "info": "..." } }, but not this.
-         * So we need to throw the response directly.
+         * In most cases, failed edit will throw a MediaWikiApiError like `{ "error": { "code": "editconflict", "info": "..." } }`, but not `{ "edit": { "result": "Failure" } }`.
+         * We need to build a MediaWikiApiError manually.
          * @see https://github.com/inpageedit/inpageedit-next/issues/13
          */
         throw new MediaWikiApiError(

--- a/packages/core/src/models/WikiPage/types/WikiPageActionEdit.ts
+++ b/packages/core/src/models/WikiPage/types/WikiPageActionEdit.ts
@@ -1,7 +1,7 @@
 import { WatchlistAction } from './WatchlistAction.js'
 
 /**
- * Result of MediaWiki edit action
+ * Request body of MediaWiki edit action
  * @see https://www.mediawiki.org/wiki/API:Edit
  */
 export interface WikiPageActionEditRequest {


### PR DESCRIPTION
## Summary by Sourcery

更新 wiki 页面编辑 API，使其使用带类型的请求/响应模型，并在 HTTP 状态为 200 时也拒绝不成功的编辑。

新特性：
- 为 wiki 页面编辑操作引入强类型的 `WikiPageActionEditRequest` 和 `WikiPageActionEditResult` 接口。

错误修复：
- 当编辑结果不成功时，即使 HTTP 响应状态为 200，wiki 页面编辑 API 也会返回拒绝（失败）。

改进：
- 优化 wiki 页面模型方法，使其使用新的强类型编辑请求和响应结构。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update wiki page edit API to use typed request/response models and to reject unsuccessful edits even when the HTTP status is 200.

New Features:
- Introduce strongly typed WikiPageActionEditRequest and WikiPageActionEditResult interfaces for wiki page edit operations.

Bug Fixes:
- Make wiki page edit API reject when the edit result is not successful, even if the HTTP response status is 200.

Enhancements:
- Refine wiki page model methods to use the new strongly typed edit request and response structures.

</details>

新特性：
- 为 wiki 页面编辑操作引入类型化的 `WikiPageActionEditRequest` 和 `WikiPageActionEditResult` 接口。

错误修复：
- 使 wiki 页面编辑 API 在编辑结果不成功时进行 reject，即使 HTTP 状态码为 200。

增强改进：
- 更新 wiki 页面模型方法，以使用新的强类型编辑请求和响应结构。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新 wiki 页面编辑 API，使其使用带类型的请求/响应模型，并在 HTTP 状态为 200 时也拒绝不成功的编辑。

新特性：
- 为 wiki 页面编辑操作引入强类型的 `WikiPageActionEditRequest` 和 `WikiPageActionEditResult` 接口。

错误修复：
- 当编辑结果不成功时，即使 HTTP 响应状态为 200，wiki 页面编辑 API 也会返回拒绝（失败）。

改进：
- 优化 wiki 页面模型方法，使其使用新的强类型编辑请求和响应结构。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update wiki page edit API to use typed request/response models and to reject unsuccessful edits even when the HTTP status is 200.

New Features:
- Introduce strongly typed WikiPageActionEditRequest and WikiPageActionEditResult interfaces for wiki page edit operations.

Bug Fixes:
- Make wiki page edit API reject when the edit result is not successful, even if the HTTP response status is 200.

Enhancements:
- Refine wiki page model methods to use the new strongly typed edit request and response structures.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新 wiki 页面编辑 API，使其使用带类型的请求/响应模型，并在 HTTP 状态为 200 时也拒绝不成功的编辑。

新特性：
- 为 wiki 页面编辑操作引入强类型的 `WikiPageActionEditRequest` 和 `WikiPageActionEditResult` 接口。

错误修复：
- 当编辑结果不成功时，即使 HTTP 响应状态为 200，wiki 页面编辑 API 也会返回拒绝（失败）。

改进：
- 优化 wiki 页面模型方法，使其使用新的强类型编辑请求和响应结构。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update wiki page edit API to use typed request/response models and to reject unsuccessful edits even when the HTTP status is 200.

New Features:
- Introduce strongly typed WikiPageActionEditRequest and WikiPageActionEditResult interfaces for wiki page edit operations.

Bug Fixes:
- Make wiki page edit API reject when the edit result is not successful, even if the HTTP response status is 200.

Enhancements:
- Refine wiki page model methods to use the new strongly typed edit request and response structures.

</details>

新特性：
- 为 wiki 页面编辑操作引入类型化的 `WikiPageActionEditRequest` 和 `WikiPageActionEditResult` 接口。

错误修复：
- 使 wiki 页面编辑 API 在编辑结果不成功时进行 reject，即使 HTTP 状态码为 200。

增强改进：
- 更新 wiki 页面模型方法，以使用新的强类型编辑请求和响应结构。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新 wiki 页面编辑 API，使其使用带类型的请求/响应模型，并在 HTTP 状态为 200 时也拒绝不成功的编辑。

新特性：
- 为 wiki 页面编辑操作引入强类型的 `WikiPageActionEditRequest` 和 `WikiPageActionEditResult` 接口。

错误修复：
- 当编辑结果不成功时，即使 HTTP 响应状态为 200，wiki 页面编辑 API 也会返回拒绝（失败）。

改进：
- 优化 wiki 页面模型方法，使其使用新的强类型编辑请求和响应结构。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update wiki page edit API to use typed request/response models and to reject unsuccessful edits even when the HTTP status is 200.

New Features:
- Introduce strongly typed WikiPageActionEditRequest and WikiPageActionEditResult interfaces for wiki page edit operations.

Bug Fixes:
- Make wiki page edit API reject when the edit result is not successful, even if the HTTP response status is 200.

Enhancements:
- Refine wiki page model methods to use the new strongly typed edit request and response structures.

</details>

</details>

</details>