### PR TITLE
fix(in-article-links): handle `veaction` param when adding quick edit links

### DIFF
--- a/packages/core/src/plugins/in-article-links/index.tsx
+++ b/packages/core/src/plugins/in-article-links/index.tsx
@@ -192,7 +192,16 @@ export class PluginInArticleLinks extends BasePlugin<{
           }
           return false
         })
+
+        // Handle deduplicate anchors within the same .mw-editsection container
+        const uniqueAnchors = new Map<Element | null, InArticleWikiAnchorMetadata>()
         anchors.forEach((info) => {
+          const { $el } = info
+          const container = $el.closest('.mw-editsection')
+          uniqueAnchors.set(container, info)
+        })
+
+        uniqueAnchors.forEach((info) => {
           const { $el, title, pageId, params } = info
           if ($el.dataset.ipeEditMounted) {
             return

--- a/packages/core/src/services/WikiTitleService.ts
+++ b/packages/core/src/services/WikiTitleService.ts
@@ -212,7 +212,13 @@ export class WikiTitleService extends Service {
     }
     const params = url.searchParams
     const hash = url.hash.replace('#', '')
-    const action = params.get('action') || 'view'
+    let action = params.get('action') || 'view'
+    if (
+      params.get('veaction') === 'edit' ||
+      params.get('veaction') === 'editsource'
+    ) {
+      action = 'edit'
+    }
     const titleParam = params.get('title') || ''
     const curid = parseInt(params.get('curid') || '0', 10)
     const oldid = parseInt(params.get('oldid') || '0', 10)


### PR DESCRIPTION
当偏好使用2017版源代码编辑器时，有时无法正确插入章节编辑按钮，故在WikiTitleService引入`veaction`参数的处理。

这会导致一个问题，当用户开启同时显示两个编辑器标签时，铅笔按钮会被插入两次，故在in-article-links引入去重逻辑。

## Summary by Sourcery

处理文章内编辑锚点的重复问题，并使编辑操作检测与 veaction 参数保持一致。

Bug Fixes:
- 对文章内编辑锚点去重，在挂载行内编辑时，对于同一目标只使用最后一个锚点。
- 在 WikiTitleService 中将带有 `veaction=edit/editsource` 的 URL 视为编辑操作，从而正确解析来自 VisualEditor 的编辑链接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle duplicate in-article edit anchors and align edit action detection with veaction parameters.

Bug Fixes:
- Deduplicate in-article edit anchors so only the last anchor for a given target is used when mounting inline editing.
- Treat veaction=edit/editsource URLs as edit actions in WikiTitleService to correctly interpret VisualEditor edit links.

</details>