### PR TITLE
fix(quick-upload): media query for grid mobile support

### DIFF
--- a/packages/core/src/plugins/quick-upload/index.tsx
+++ b/packages/core/src/plugins/quick-upload/index.tsx
@@ -974,15 +974,7 @@ export class PluginQuickUpload extends BasePlugin {
         style={{ display: 'grid', gap: '12px' }}
       >
         {progressBar}
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: 'minmax(0, 40%) minmax(0, 1fr)',
-            gap: '12px',
-            alignItems: 'start',
-            minWidth: 0,
-          }}
-        >
+        <div className="ipe-quickUpload__layout">
           {leftPanel}
           {rightPanel}
         </div>

--- a/packages/core/src/plugins/quick-upload/style.scss
+++ b/packages/core/src/plugins/quick-upload/style.scss
@@ -26,6 +26,17 @@
     }
   }
 
+  &__layout {
+    display: grid;
+    grid-template-columns: minmax(0, 40%) minmax(0, 1fr);
+    gap: 0.75rem;
+    align-items: start;
+
+    @media (max-width: 768px) {
+      grid-template-columns: 1fr;
+    }
+  }
+
   &__preview {
     text-align: center;
     margin-bottom: 1rem;


### PR DESCRIPTION
Fixes the grid overlapping each other on 768px< screen size

| Before | After |
| :--- | :--- |
| <img width="297.5" alt="image" src="https://github.com/user-attachments/assets/4e741b86-5005-4f1a-a6a6-90960247ea3b" /> | <img width="297.5" alt="image" src="https://github.com/user-attachments/assets/b55108d1-ae8e-4c4b-a553-016f0da32e0d" /> |

## Summary by Sourcery

为快速上传面板定义一个可复用的布局类，并调整其在移动端屏幕上的网格行为，以防止元素重叠。

Bug 修复：
- 修复在宽度小于 768px 的屏幕上快速上传网格布局重叠的问题，改为将面板堆叠为单列显示。

增强：
- 将内联网格布局样式提取到一个专门用于快速上传布局容器的 SCSS 类中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Define a reusable layout class for the quick upload panels and adjust its grid behavior for mobile screens to prevent overlapping.

Bug Fixes:
- Fix overlapping quick upload grid layout on screens narrower than 768px by stacking panels in a single column.

Enhancements:
- Extract inline grid layout styles into a dedicated SCSS class for the quick upload layout container.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为快速上传面板定义一个可复用的布局类，并调整其在移动端屏幕上的网格行为，以防止元素重叠。

Bug 修复：
- 修复在宽度小于 768px 的屏幕上快速上传网格布局重叠的问题，改为将面板堆叠为单列显示。

增强：
- 将内联网格布局样式提取到一个专门用于快速上传布局容器的 SCSS 类中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Define a reusable layout class for the quick upload panels and adjust its grid behavior for mobile screens to prevent overlapping.

Bug Fixes:
- Fix overlapping quick upload grid layout on screens narrower than 768px by stacking panels in a single column.

Enhancements:
- Extract inline grid layout styles into a dedicated SCSS class for the quick upload layout container.

</details>

</details>