### PR TITLE
fix: prefer local file repo on WikiFileService to get correct file url on wiki farms

### DIFF
--- a/packages/core/src/services/WikiFileService.ts
+++ b/packages/core/src/services/WikiFileService.ts
@@ -82,7 +82,7 @@ export class WikiFileService extends Service {
     return this.ctx.wiki.fileRepos || []
   }
   get defaultFileRepo(): WikiFileRepo | undefined {
-    return this.fileRepos[0]
+    return this.localFileRepo || this.fileRepos[0]
   }
   get localFileRepo(): WikiFileRepo | undefined {
     return this.fileRepos.find((repo) => repo.local)


### PR DESCRIPTION
On wiki farms, the current `WikiMetadataService.fileRepos` will return the commons image wiki which will of course return a broken link since that image does not exist in commons.

Preferring `WikiFileService.localFileRepo` will let the link use the actual local wiki instead, and hence give the user the correct link.

This is a problem since the most prominent usage of this is the 'Open link page' link on quick-upload.

Examples:
- wiki.gg:
  - Incorrect: `https://commons.wiki.gg/images/GaiaEarthSimulatorLogo.png`
  - Correct: `https://scienceadventure.wiki.gg/images/GaiaEarthSimulatorLogo.png`
- Fandom:
  - Incorrect: `https://static.wikia.nocookie.net/ucp-internal-test-starter-commons/images/6/6a/Luciencommander.png`
  - Correct: `https://tds.fandom.com/wiki/File:Luciencommander.png`

## Summary by Sourcery

Bug Fixes:
- 通过在可用时默认使用本地文件仓库而不是第一个配置的仓库，修复了 wiki farm 上文件 URL 不正确的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect file URLs on wiki farms by defaulting to the local file repository when available instead of the first configured repo.

</details>