### PR TITLE
feat(quick-edit): editSummary variables support 为编辑摘要提供变量支持（并没支持）

### DIFF
--- a/packages/core/src/plugins/quick-edit/index.tsx
+++ b/packages/core/src/plugins/quick-edit/index.tsx
@@ -638,7 +638,17 @@ export class PluginQuickEdit extends BasePlugin {
         }}
         onClick={(e) => {
           e.preventDefault()
-          this.showModal(JSON.parse(e.currentTarget.dataset.payload ?? '{}') ?? payload)
+          this.showModal((elPayload => {
+            if (!elPayload) {
+              return payload;
+            }
+            try {
+              return JSON.parse(elPayload);
+            } catch {
+              // 应该打个log提示一下
+              return payload;
+            }
+          })(e.currentTarget.dataset.payload));
         }}
       >
         {icon}


### PR DESCRIPTION
#36 
*让quick-edit读取编辑按钮上的payload：从dataset获取创建按钮时存入、可能被其他插件修改的payload
*为编辑摘要提供变量支持：基于正则对${name}形式文本替换，替换文本数据来源为payload

## Summary by Sourcery

为 quick-edit 插件添加对可从按钮载荷数据填充的模板化编辑摘要的支持。

New Features:
- 允许编辑摘要使用 `${name}` 风格的模板变量，这些变量将从与 quick-edit 触发按钮关联的 JSON 载荷中解析得到。

Enhancements:
- 让 quick-edit 从触发按钮的 dataset 中读取其配置载荷，而不是通过点击事件处理器直接传递载荷对象。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for templated edit summaries that are populated from button payload data in the quick-edit plugin.

New Features:
- Allow edit summaries to use `${name}`-style template variables resolved from a JSON payload associated with the quick-edit trigger button.

Enhancements:
- Make quick-edit read its configuration payload from the triggering button's dataset instead of passing the payload object directly through the click handler.

</details>

新功能：
- 允许编辑摘要使用 `${name}` 风格的模板变量，并从 JSON payload 中解析这些变量。
- 使快速编辑对话框能够从触发按钮的 dataset 属性中读取其 payload。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 quick-edit 插件添加对可从按钮载荷数据填充的模板化编辑摘要的支持。

New Features:
- 允许编辑摘要使用 `${name}` 风格的模板变量，这些变量将从与 quick-edit 触发按钮关联的 JSON 载荷中解析得到。

Enhancements:
- 让 quick-edit 从触发按钮的 dataset 中读取其配置载荷，而不是通过点击事件处理器直接传递载荷对象。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for templated edit summaries that are populated from button payload data in the quick-edit plugin.

New Features:
- Allow edit summaries to use `${name}`-style template variables resolved from a JSON payload associated with the quick-edit trigger button.

Enhancements:
- Make quick-edit read its configuration payload from the triggering button's dataset instead of passing the payload object directly through the click handler.

</details>

</details>