### PR TITLE
feat(quick-upload): open file url/open file page

### DIFF
--- a/packages/core/src/plugins/quick-upload/index.tsx
+++ b/packages/core/src/plugins/quick-upload/index.tsx
@@ -506,14 +506,24 @@ export class PluginQuickUpload extends BasePlugin {
           <div style={{ display: 'flex', gap: '10px', alignItems: 'center', flexWrap: 'wrap' }}>
             <span style={{ fontSize: '12px', opacity: 0.8 }}>{file.type || $`Unknown type`}</span>
             {item.fileUrl ? (
-              <a
-                href={item.fileUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                style={{ fontSize: '12px' }}
-              >
-                {$`Open file page`}
-              </a>
+              <>
+                <a
+                  href={item.fileUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ fontSize: '12px' }}
+                >
+                  {$`Open file URL`}
+                </a>
+                <a
+                  href={this.ctx.wiki.getUrl(`File:${item.filename}`)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ fontSize: '12px' }}
+                >
+                  {$`Open file page`}
+                </a>
+              </>
             ) : null}
           </div>
         </section>


### PR DESCRIPTION
#31 renames the current "Open file page" to "Open file URL" and adds a new "Open file page" that actually opens the file's page on the wiki

https://github.com/user-attachments/assets/9938f0bc-bb62-4678-ac81-9185b73108e2

## Summary by Sourcery

在快速上传界面中添加单独的操作，用于打开已上传文件的直链 URL，以及打开其对应的维基文件页面。

新功能：
- 在快速上传面板中新增一个链接，用于打开已上传文件的维基页面。

改进：
- 重命名现有的快速上传链接标签，以明确其是打开文件的直链 URL，而不是维基页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add distinct actions in the quick upload UI to open the uploaded file’s direct URL and to open its wiki file page.

New Features:
- Expose a new link in the quick upload panel to open the uploaded file’s wiki page.

Enhancements:
- Rename the existing quick upload link label to clarify that it opens the file’s direct URL rather than the wiki page.

</details>