### PR TITLE
feat(quick-upload): use wiki's allowed file extensions for upload queue instead of hardcoding it

### DIFF
--- a/packages/core/src/plugins/quick-upload/index.tsx
+++ b/packages/core/src/plugins/quick-upload/index.tsx
@@ -56,7 +56,16 @@ const PreviewPlaceholderNA = ({ $ }: { $: (strings: TemplateStringsArray) => str
       .default('[IPE-NEXT] Quick upload'),
   })
 )
-@Inject(['modal', '$', 'wikiTitle', 'wikiFile', 'quickPreview', 'preferences'])
+@Inject([
+  'modal',
+  '$',
+  'wikiTitle',
+  'wikiFile',
+  'quickPreview',
+  'preferences',
+  'wiki',
+  'apiService',
+])
 export class PluginQuickUpload extends BasePlugin {
   constructor(public ctx: InPageEdit) {
     super(ctx, {}, 'quick-upload')
@@ -176,7 +185,10 @@ export class PluginQuickUpload extends BasePlugin {
     })
 
     const defaultSummary = (await this.ctx.preferences.get('quickUpload.summary')) || ''
-    const exts = this.ctx.wiki.allowedFileExtensions
+    const repo = this.ctx.wikiFile.writableFileRepo
+    const targetApi = repo ? this.ctx.apiService.getClientByFileRepo(repo) : undefined
+    const exts = await this.ctx.wiki.getAllowedFileExtensions(targetApi)
+
     const accept = exts.map((e) => `.${e}`).join(',')
     const confirmThreshold = 20
 

--- a/packages/core/src/plugins/quick-upload/index.tsx
+++ b/packages/core/src/plugins/quick-upload/index.tsx
@@ -330,7 +330,7 @@ export class PluginQuickUpload extends BasePlugin {
         showMessage(
           'warning',
           $`File type not allowed`,
-          <span>
+          <span style={{ wordWrap: 'break-word' }}>
             {rejectedCount === 1
               ? $`1 file skipped! Only ${accept} are allowed by this wiki.`
               : $`${rejectedCount} files skipped! Only ${accept} are allowed by this wiki.`}

--- a/packages/core/src/plugins/quick-upload/index.tsx
+++ b/packages/core/src/plugins/quick-upload/index.tsx
@@ -324,6 +324,16 @@ export class PluginQuickUpload extends BasePlugin {
 
     const addFiles = (files: File[]) => {
       const accepted = files.filter((f) => this.isFileAccepted(f, String(accept || '')))
+
+      const rejectedCount = files.length - accepted.length
+      if (rejectedCount > 0) {
+        showMessage(
+          'warning',
+          $`File type not allowed`,
+          $`${rejectedCount} file(s) skipped! Only ${accept} are allowed by this wiki.`
+        )
+      }
+
       if (!accepted.length) return
 
       const newItems: UploadItem[] = accepted.map((file) => ({

--- a/packages/core/src/plugins/quick-upload/index.tsx
+++ b/packages/core/src/plugins/quick-upload/index.tsx
@@ -177,10 +177,7 @@ export class PluginQuickUpload extends BasePlugin {
 
     const defaultSummary = (await this.ctx.preferences.get('quickUpload.summary')) || ''
     const exts = this.ctx.wiki.allowedFileExtensions
-    const accept =
-      exts.length > 0
-        ? exts.map((e) => `.${e}`).join(',')
-        : 'image/*,video/*,audio/*,application/pdf,application/ogg'
+    const accept = exts.map((e) => `.${e}`).join(',')
     const confirmThreshold = 20
 
     let items: UploadItem[] = []

--- a/packages/core/src/plugins/quick-upload/index.tsx
+++ b/packages/core/src/plugins/quick-upload/index.tsx
@@ -176,7 +176,11 @@ export class PluginQuickUpload extends BasePlugin {
     })
 
     const defaultSummary = (await this.ctx.preferences.get('quickUpload.summary')) || ''
-    const accept = 'image/*,video/*,audio/*,application/pdf'
+    const exts = this.ctx.wiki.allowedFileExtensions
+    const accept =
+      exts.length > 0
+        ? exts.map((e) => `.${e}`).join(',')
+        : 'image/*,video/*,audio/*,application/pdf,application/ogg'
     const confirmThreshold = 20
 
     let items: UploadItem[] = []

--- a/packages/core/src/plugins/quick-upload/index.tsx
+++ b/packages/core/src/plugins/quick-upload/index.tsx
@@ -330,7 +330,11 @@ export class PluginQuickUpload extends BasePlugin {
         showMessage(
           'warning',
           $`File type not allowed`,
-          $`${rejectedCount} file(s) skipped! Only ${accept} are allowed by this wiki.`
+          <span>
+            {rejectedCount === 1
+              ? $`1 file skipped! Only ${accept} are allowed by this wiki.`
+              : $`${rejectedCount} files skipped! Only ${accept} are allowed by this wiki.`}
+          </span>
         )
       }
 

--- a/packages/core/src/services/WikiFileService.ts
+++ b/packages/core/src/services/WikiFileService.ts
@@ -88,7 +88,15 @@ export class WikiFileService extends Service {
     return this.fileRepos.find((repo) => repo.local)
   }
   get writableFileRepo(): WikiFileRepo | undefined {
-    return this.fileRepos.find((repo) => repo.canUpload)
+    const repos = this.fileRepos
+    const canUpload = (r: WikiFileRepo) => r.canUpload === true || (r.canUpload as any) === ''
+    const explicit = repos.find(canUpload)
+    if (explicit) return explicit
+    const local = repos.find((r) => r.local)
+    if (!local || !canUpload(local)) {
+      return repos.find((r) => !r.local && r.scriptDirUrl)
+    }
+    return undefined
   }
 
   getFileName(title: string | IWikiTitle) {

--- a/packages/core/src/services/WikiFileService.ts
+++ b/packages/core/src/services/WikiFileService.ts
@@ -89,7 +89,7 @@ export class WikiFileService extends Service {
   }
   get writableFileRepo(): WikiFileRepo | undefined {
     const repos = this.fileRepos
-    const canUpload = (r: WikiFileRepo) => r.canUpload === true || (r.canUpload as any) === ''
+    const canUpload = (r: WikiFileRepo) => !!r.canUpload
     const explicit = repos.find(canUpload)
     if (explicit) return explicit
     const local = repos.find((r) => r.local)
@@ -129,7 +129,7 @@ export class WikiFileService extends Service {
 
   async upload(params: Partial<UploadFileParams>, repo?: WikiFileRepo) {
     repo = repo || this.writableFileRepo
-    if (!repo?.canUpload) {
+    if (!repo) {
       throw new Error('No writable file repository found')
     }
 

--- a/packages/core/src/services/WikiMetadataService.tsx
+++ b/packages/core/src/services/WikiMetadataService.tsx
@@ -35,7 +35,7 @@ export class WikiMetadataService extends Service {
   private readonly QUERY_DATA: Readonly<Record<keyof WikiMetadataKindMap, MwApiParams>> = {
     siteinfo: {
       meta: 'siteinfo|filerepoinfo',
-      siprop: 'general|specialpagealiases|namespacealiases|namespaces|magicwords',
+      siprop: 'general|specialpagealiases|namespacealiases|namespaces|magicwords|fileextensions',
       friprop: 'canUpload|displayname|initialCapital|local|name|rootUrl|scriptDirUrl|thumbUrl|url',
     },
     userinfo: { meta: 'userinfo', uiprop: 'groups|rights|blockinfo|options' },
@@ -229,6 +229,9 @@ export class WikiMetadataService extends Service {
   }
   get magicWords() {
     return this.siteInfo.magicwords
+  }
+  get allowedFileExtensions(): string[] {
+    return (this.siteInfo.fileextensions ?? []).map((e) => e.ext)
   }
 
   // userInfo

--- a/packages/core/src/services/WikiMetadataService.tsx
+++ b/packages/core/src/services/WikiMetadataService.tsx
@@ -27,7 +27,7 @@ interface WikiMetadataKindMap {
 @Inject(['api', 'storage'])
 export class WikiMetadataService extends Service {
   private readonly _data: WikiMetadataKindMap = {} as any
-  private readonly CACHE_VERSION = 4
+  private readonly CACHE_VERSION = 5
   private readonly CACHE_TTL: Readonly<Record<keyof WikiMetadataKindMap, number>> = {
     siteinfo: 1000 * 60 * 60 * 24 * 3, // 3 days
     userinfo: 1000 * 60 * 30, // 30 minutes
@@ -231,7 +231,7 @@ export class WikiMetadataService extends Service {
     return this.siteInfo.magicwords
   }
   get allowedFileExtensions(): string[] {
-    return (this.siteInfo.fileextensions ?? []).map((e) => e.ext)
+    return this.siteInfo.fileextensions.map((e) => e.ext)
   }
 
   // userInfo

--- a/packages/core/src/services/WikiMetadataService.tsx
+++ b/packages/core/src/services/WikiMetadataService.tsx
@@ -144,14 +144,16 @@ export class WikiMetadataService extends Service {
     }
   }
 
-  private getCacheKey<T extends keyof WikiMetadataKindMap>(kind: T): string {
-    return `${kind}:${new URL(this.ctx.api.config.baseURL).pathname.replace(/^\//, '')}`
+  private getCacheKey<T extends keyof WikiMetadataKindMap>(kind: T, api = this.api): string {
+    const url = new URL(api.config.baseURL, window.location.origin)
+    return `${kind}:${url.host}/${url.pathname.replace(/^\//, '')}`
   }
 
-  async fetchFromApi<T extends keyof WikiMetadataKindMap>(
-    kind: T
+  private async fetchFromApi<T extends keyof WikiMetadataKindMap>(
+    kind: T,
+    api = this.api
   ): Promise<WikiMetadataKindMap[T]> {
-    return this.api
+    return api
       .get({
         action: 'query',
         ...this.QUERY_DATA[kind],
@@ -173,18 +175,23 @@ export class WikiMetadataService extends Service {
   }
 
   async fetchFromCache<T extends keyof WikiMetadataKindMap>(
-    kind: T
+    kind: T,
+    api = this.api
   ): Promise<WikiMetadataKindMap[T] | null> {
-    const key = this.getCacheKey(kind)
+    const key = this.getCacheKey(kind, api)
     const data = await this.CACHE_DB.get(key, this.CACHE_TTL[kind])
     return data as WikiMetadataKindMap[T] | null
   }
-  async saveToCache<T extends keyof WikiMetadataKindMap>(kind: T, data: WikiMetadataKindMap[T]) {
-    const key = this.getCacheKey(kind)
+  async saveToCache<T extends keyof WikiMetadataKindMap>(
+    kind: T,
+    data: WikiMetadataKindMap[T],
+    api = this.api
+  ) {
+    const key = this.getCacheKey(kind, api)
     return this.CACHE_DB.set(key, data)
   }
-  async invalidateCache<T extends keyof WikiMetadataKindMap>(kind: T) {
-    const key = this.getCacheKey(kind)
+  async invalidateCache<T extends keyof WikiMetadataKindMap>(kind: T, api = this.api) {
+    const key = this.getCacheKey(kind, api)
     return this.CACHE_DB.delete(key)
   }
   private async onClearCache() {
@@ -232,6 +239,16 @@ export class WikiMetadataService extends Service {
   }
   get allowedFileExtensions(): string[] {
     return this.siteInfo.fileextensions.map((e) => e.ext)
+  }
+  async getAllowedFileExtensions(targetApi?: any): Promise<string[]> {
+    if (!targetApi) {
+      return this.allowedFileExtensions
+    }
+
+    const cached = await this.fetchFromCache('siteinfo', targetApi)
+    const siteinfo = cached ?? (await this.fetchFromApi('siteinfo', targetApi))
+    if (!cached) this.saveToCache('siteinfo', siteinfo, targetApi)
+    return siteinfo.fileextensions.map((e: { ext: string }) => e.ext)
   }
 
   // userInfo

--- a/packages/core/src/types/WikiMetadata.ts
+++ b/packages/core/src/types/WikiMetadata.ts
@@ -5,6 +5,7 @@ export interface WikiSiteInfo {
   magicwords: WikiMagicWord[]
   namespaces: Record<string, WikiNamespace>
   repos: WikiFileRepo[]
+  fileextensions?: { ext: string }[]
 }
 
 export interface WikiSiteGeneralInfo {

--- a/packages/core/src/types/WikiMetadata.ts
+++ b/packages/core/src/types/WikiMetadata.ts
@@ -5,7 +5,7 @@ export interface WikiSiteInfo {
   magicwords: WikiMagicWord[]
   namespaces: Record<string, WikiNamespace>
   repos: WikiFileRepo[]
-  fileextensions?: { ext: string }[]
+  fileextensions: { ext: string }[]
 }
 
 export interface WikiSiteGeneralInfo {


### PR DESCRIPTION
Instead of letting users queue a file that can't even be uploaded, or perhaps arbitrarily not letting them queue a file that can actually be uploaded, validate it on queue instead:

https://github.com/user-attachments/assets/359e12ef-87d3-4787-802b-5e959d9270ac

Implementation has `fileextensions` as optional, and with a fallback since users with cached data will have errors thrown at. It's something you can remove in the future once everyone's cache is up to date

## Summary by Sourcery

根据 wiki 中配置的允许文件扩展名来校验快速上传的文件，并向用户展示被禁止的文件选择。

New Features:
- 使用 wiki 的允许文件扩展名来构建快速上传文件选择器的 `accept` 过滤器，并对加入队列的文件进行校验。

Bug Fixes:
- 当用户选择的文件因类型不被该 wiki 允许而被跳过时，向用户发出通知，而不是静默忽略这些文件。

Enhancements:
- 通过新的 `WikiMetadataService` 访问器，从 wiki 的 siteinfo 元数据中暴露允许的文件扩展名；在扩展名不可用时提供后备方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Validate quick uploads against wiki-configured allowed file extensions and surface disallowed selections to the user.

New Features:
- Use the wiki's allowed file extensions to build the quick upload file picker accept filter and validate queued files.

Bug Fixes:
- Notify users when selected files are skipped because their types are not allowed by the wiki, instead of silently ignoring them.

Enhancements:
- Expose allowed file extensions from wiki siteinfo metadata via a new WikiMetadataService accessor, with a fallback when extensions are unavailable.

</details>

新功能：
- 根据 wiki 配置的允许文件扩展名校验快速上传的文件选择，并在文件被跳过时告知用户。

改进：
- 从 wiki 元数据中暴露允许的文件扩展名，并使用它们构建上传的 accept 过滤器；当没有可用扩展名时，提供向后兼容的回退机制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

根据 wiki 中配置的允许文件扩展名来校验快速上传的文件，并向用户展示被禁止的文件选择。

New Features:
- 使用 wiki 的允许文件扩展名来构建快速上传文件选择器的 `accept` 过滤器，并对加入队列的文件进行校验。

Bug Fixes:
- 当用户选择的文件因类型不被该 wiki 允许而被跳过时，向用户发出通知，而不是静默忽略这些文件。

Enhancements:
- 通过新的 `WikiMetadataService` 访问器，从 wiki 的 siteinfo 元数据中暴露允许的文件扩展名；在扩展名不可用时提供后备方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Validate quick uploads against wiki-configured allowed file extensions and surface disallowed selections to the user.

New Features:
- Use the wiki's allowed file extensions to build the quick upload file picker accept filter and validate queued files.

Bug Fixes:
- Notify users when selected files are skipped because their types are not allowed by the wiki, instead of silently ignoring them.

Enhancements:
- Expose allowed file extensions from wiki siteinfo metadata via a new WikiMetadataService accessor, with a fallback when extensions are unavailable.

</details>

</details>