### PR TITLE
fix(quick-upload): bulk upload confirm infinite loop

### DIFF
--- a/packages/core/src/plugins/quick-upload/index.tsx
+++ b/packages/core/src/plugins/quick-upload/index.tsx
@@ -258,7 +258,7 @@ export class PluginQuickUpload extends BasePlugin {
       return false
     }
 
-    type UploadMode = 'all' | 'resume' | 'retry'
+    type UploadMode = 'all' | 'confirmed' | 'resume' | 'retry'
 
     const getUploadCandidates = (mode: UploadMode, list: UploadItem[]) => {
       if (mode === 'retry') return list.filter((it) => shouldRetryItem(it))
@@ -721,7 +721,7 @@ export class PluginQuickUpload extends BasePlugin {
           )
           return
         }
-        if (items.length > confirmThreshold) {
+        if (mode !== 'confirmed' && items.length > confirmThreshold) {
           this.ctx.modal.confirm(
             {
               title: $`Confirm bulk upload`,
@@ -737,7 +737,7 @@ export class PluginQuickUpload extends BasePlugin {
             },
             (confirmed) => {
               if (confirmed) {
-                void uploadAll('all')
+                void uploadAll('confirmed')
               }
               return true
             }


### PR DESCRIPTION
Having a queue of over 20 forces the user to confirm whether they are sure to upload or not. However, `uploadAll('all')` callback gets run again when the user tries to confirm, hence an infinite loop of the confirmation modal.

New `confirmed` state now allows the check to pass properly when the user confirms in the modal.

## Summary by Sourcery

错误修复：
- 通过引入专门的“已确认上传”模式，确保当批量上传超过确认阈值时，只会显示一次确认弹窗。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure bulk uploads over the confirmation threshold only show the confirmation modal once by introducing a dedicated confirmed upload mode.

</details>