### PR TITLE
fix(quick-move): untrusted form submission prevent move

### DIFF
--- a/packages/core/src/plugins/quick-move/index.tsx
+++ b/packages/core/src/plugins/quick-move/index.tsx
@@ -207,7 +207,7 @@ export class PluginQuickMove extends BasePlugin {
         label: $`Move`,
         className: 'is-primary is-ghost',
         method: () => {
-          formRef?.dispatchEvent(new Event('submit'))
+          formRef?.requestSubmit()
         },
       },
     ])


### PR DESCRIPTION
`dispatchEvent(new Event('submit'))` is untrusted by the browser, and on some wikifarms such as wiki.gg, it won't allow the submission at all, and hence will prevent the file from actually being moved.

## Summary by Sourcery

错误修复：
- 通过将合成的提交事件替换为可信任的表单提交调用，修复了在某些平台上快速移动操作被阻止的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix quick-move actions being blocked on some platforms by replacing synthetic submit events with a trusted form submission call.

</details>