### PR TITLE
fix(quick-upload): guard against missing fileextensions and simplify writableFileRepo

### DIFF
--- a/packages/core/src/services/WikiFileService.ts
+++ b/packages/core/src/services/WikiFileService.ts
@@ -88,15 +88,12 @@ export class WikiFileService extends Service {
     return this.fileRepos.find((repo) => repo.local)
   }
   get writableFileRepo(): WikiFileRepo | undefined {
-    const repos = this.fileRepos
-    const canUpload = (r: WikiFileRepo) => !!r.canUpload
-    const explicit = repos.find(canUpload)
-    if (explicit) return explicit
-    const local = repos.find((r) => r.local)
-    if (!local || !canUpload(local)) {
-      return repos.find((r) => !r.local && r.scriptDirUrl)
-    }
-    return undefined
+    // Prefer a repo the user can upload to; otherwise fall back to a non-local
+    // repo that exposes its own api.php (e.g. a writable shared/foreign repo).
+    return (
+      this.fileRepos.find((repo) => repo.canUpload) ??
+      this.fileRepos.find((repo) => !repo.local && repo.scriptDirUrl)
+    )
   }
 
   getFileName(title: string | IWikiTitle) {

--- a/packages/core/src/services/WikiMetadataService.tsx
+++ b/packages/core/src/services/WikiMetadataService.tsx
@@ -2,6 +2,7 @@ import { Inject, InPageEdit, Schema, Service } from '@/InPageEdit'
 import { WikiSiteInfo, WikiUserBlockInfo, WikiUserInfo } from '@/types/WikiMetadata'
 import { AbstractIPEStorageManager } from './storage'
 import { MwApiParams } from 'wiki-saikou'
+import type { MwApi } from 'wiki-saikou/browser'
 
 declare module '@/InPageEdit' {
   interface InPageEdit {
@@ -238,9 +239,9 @@ export class WikiMetadataService extends Service {
     return this.siteInfo.magicwords
   }
   get allowedFileExtensions(): string[] {
-    return this.siteInfo.fileextensions.map((e) => e.ext)
+    return (this.siteInfo.fileextensions ?? []).map((e) => e.ext)
   }
-  async getAllowedFileExtensions(targetApi?: any): Promise<string[]> {
+  async getAllowedFileExtensions(targetApi?: MwApi): Promise<string[]> {
     if (!targetApi) {
       return this.allowedFileExtensions
     }
@@ -248,7 +249,7 @@ export class WikiMetadataService extends Service {
     const cached = await this.fetchFromCache('siteinfo', targetApi)
     const siteinfo = cached ?? (await this.fetchFromApi('siteinfo', targetApi))
     if (!cached) this.saveToCache('siteinfo', siteinfo, targetApi)
-    return siteinfo.fileextensions.map((e: { ext: string }) => e.ext)
+    return (siteinfo.fileextensions ?? []).map((e) => e.ext)
   }
 
   // userInfo

--- a/packages/core/src/types/WikiMetadata.ts
+++ b/packages/core/src/types/WikiMetadata.ts
@@ -5,7 +5,8 @@ export interface WikiSiteInfo {
   magicwords: WikiMagicWord[]
   namespaces: Record<string, WikiNamespace>
   repos: WikiFileRepo[]
-  fileextensions: { ext: string }[]
+  /** Allowed upload file extensions. Optional: older MediaWiki / some foreign repos may omit it. */
+  fileextensions?: { ext: string }[]
 }
 
 export interface WikiSiteGeneralInfo {


### PR DESCRIPTION
Follow-up to #46.

## 背景
#46 引入了「用 wiki 的 `fileextensions` 校验快速上传」的功能，但留下两个问题（见 #46 的 review）。本 PR 修复其中**阻塞性**的两点。

## 改动
- **修复崩溃风险**：`WikiSiteInfo.fileextensions` 改为 optional，`allowedFileExtensions` / `getAllowedFileExtensions` 两处 `.map` 前加 `?? []` fallback。原实现中若 foreign repo / 老版本 MediaWiki 不返回该字段，`siteInfo.fileextensions.map(...)` 会抛 `Cannot read properties of undefined`，导致上传弹窗打不开。`CACHE_VERSION` 升级只能解决本地旧缓存，解决不了远端 API 不返回该字段的情况。这也兑现了 #46 描述里承诺的 "fileextensions as optional, with a fallback"。
- **清理死代码**：`writableFileRepo` 化简为两行 `??` 查找，与原逻辑**完全等价**（原实现中 `return undefined` 不可达），可读性更好。
- **类型收紧**：`getAllowedFileExtensions(targetApi)` 的 `any` → `MwApi`。

## 未在本 PR 处理（后续讨论）
- `upload()` 的运行时语义（`writableFileRepo` 可能返回 `canUpload=false` 的 foreign repo、守卫从 `!repo?.canUpload` 弱化为 `!repo`）**保持 #46 合并后的现状未改动**——是否支持「向 foreign/shared repo 上传」属于产品决策，需 @t7ru 确认该场景是否经过实测。
- 警告文案塞入整段 `accept` 字符串、本地场景多余的异步缓存读取等 UX/性能优化。

## 验证
- 测试：51 passed / 6 files
- Typecheck：本 PR 改动的文件 0 错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

防止在快速上传时因缺少文件扩展名元数据而出错，并简化可写文件仓库的选择逻辑。

Bug 修复：
- 在推导允许上传的文件扩展名时处理缺失的 `siteinfo.fileextensions` 情况，以避免在较旧或非本地化的 MediaWiki 实例上发生运行时崩溃。

功能改进：
- 在保持现有行为和可读性的前提下，简化可写文件仓库的选择逻辑。
- 通过使用 `MwApi` 类型替代 `any`，收紧 `getAllowedFileExtensions` 的类型定义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guard quick upload against missing file extension metadata and simplify writable file repository selection.

Bug Fixes:
- Handle missing siteinfo.fileextensions when deriving allowed upload file extensions to avoid runtime crashes on older or foreign MediaWiki instances.

Enhancements:
- Simplify writable file repository selection logic while preserving behavior and readability.
- Tighten typing for getAllowedFileExtensions by using the MwApi type instead of any.

</details>