### PR TITLE
fix(core): guarantee user plugins are installed before core plugins are usable

### DIFF
--- a/packages/core/src/InPageEdit.ts
+++ b/packages/core/src/InPageEdit.ts
@@ -119,6 +119,8 @@ export class InPageEdit extends Context {
 
   // TODO: 这里不应该硬编码，暂时先这样
   async #initCorePlugins() {
+    await this.#waitForMediaWikiBase()
+
     const plugins = [
       import('@/plugins/analytics/index.js').then(({ PluginAnalytics }) => PluginAnalytics),
       import('@/plugins/in-article-links/index.js').then(
@@ -147,6 +149,18 @@ export class InPageEdit extends Context {
 
     if (import.meta.env.DEV) {
       this.plugin((await import('@/plugins/_debug/index.js')).default)
+    }
+  }
+
+  async #waitForMediaWikiBase() {
+    if (window.mw && mw.loader && typeof mw.loader.using === 'function') {
+      try {
+        await mw.loader.using('mediawiki.base')
+      } catch {}
+    } else if (window.RLQ) {
+      await new Promise<void>((resolve) => {
+        window.RLQ.push(['mediawiki.base', resolve])
+      })
     }
   }
 

--- a/packages/core/src/InPageEdit.ts
+++ b/packages/core/src/InPageEdit.ts
@@ -65,7 +65,7 @@ export class InPageEdit extends Context {
   async #init() {
     await this.#initCoreServices()
     if (this.config.autoInstallCorePlugins) {
-      this.#initCorePlugins()
+      await this.#initCorePlugins()
     }
     this.#initCoreAssets()
   }
@@ -119,14 +119,15 @@ export class InPageEdit extends Context {
 
   // TODO: 这里不应该硬编码，暂时先这样
   async #initCorePlugins() {
-    await this.#waitForMediaWikiBase()
+    const mwBaseReady = this.#waitForMediaWikiBase()
+    const { PluginPluginStore } = await import('@/plugins/plugin-store/index.js')
+    this.plugin(PluginPluginStore)
 
     const plugins = [
       import('@/plugins/analytics/index.js').then(({ PluginAnalytics }) => PluginAnalytics),
       import('@/plugins/in-article-links/index.js').then(
         ({ PluginInArticleLinks }) => PluginInArticleLinks
       ),
-      import('@/plugins/plugin-store/index.js').then(({ PluginPluginStore }) => PluginPluginStore),
       import('@/plugins/preferences-ui/index.js').then(
         ({ PluginPreferencesUI }) => PluginPreferencesUI
       ),
@@ -143,9 +144,9 @@ export class InPageEdit extends Context {
       import('@/plugins/quick-usage/index.js').then(({ PluginQuickUsage }) => PluginQuickUsage),
       import('@/plugins/toolbox/index.js').then(({ PluginToolbox }) => PluginToolbox),
     ]
-    plugins.forEach(async (plugin) => {
-      this.plugin(await plugin)
-    })
+    await Promise.all(plugins.map(async (p) => this.plugin(await p)))
+
+    await mwBaseReady
 
     if (import.meta.env.DEV) {
       this.plugin((await import('@/plugins/_debug/index.js')).default)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,9 +53,7 @@ async function autoload(
   await ipe.start()
 
   // Trigger the mw.hook
-  window.RLQ.push(() => {
-    mw.hook('InPageEdit.ready').fire(ipe)
-  })
+  mw.hook('InPageEdit.ready').fire(ipe)
 
   // Initialize global modules
   if (Array.isArray(window.__IPE_MODULES__)) {

--- a/packages/core/src/plugins/in-article-links/index.tsx
+++ b/packages/core/src/plugins/in-article-links/index.tsx
@@ -148,19 +148,9 @@ export class PluginInArticleLinks extends BasePlugin<{
   }
 
   private onContentReady(callback: ($content: JQuery<HTMLElement>) => void) {
-    const register = () => {
-      if (!window.mw) return
-      window.mw.hook('wikipage.content').add(callback)
-      const $content = (window as any).$?.('#mw-content-text')
-      if ($content?.length) callback($content)
-    }
-
-    if (window.mw && typeof window.mw.hook === 'function') {
-      register()
-    } else {
-      window.RLQ = window.RLQ || ([] as any)
-      window.RLQ.push(['mediawiki.base', register])
-    }
+    window.mw.hook('wikipage.content').add(callback)
+    const $content = (window as any).$?.('#mw-content-text')
+    if ($content?.length) callback($content)
   }
 
   async handleQuickEdit() {

--- a/packages/core/src/plugins/plugin-store/index.tsx
+++ b/packages/core/src/plugins/plugin-store/index.tsx
@@ -92,6 +92,7 @@ export class PluginPluginStore extends BasePlugin {
   static REGISTRY_INFO_STORAGE_NAME = 'plugin-store-registry'
   static REGISTRY_ETAG_STORAGE_NAME = 'psreg-etag'
   private regInfoDB: AbstractIPEStorageManager<PluginStoreRegistry>
+  public readonly whenUserPluginsReady: Promise<void>
 
   constructor(public ctx: InPageEdit) {
     super(ctx, {}, 'plugin-store')
@@ -102,10 +103,13 @@ export class PluginPluginStore extends BasePlugin {
       1,
       'indexedDB'
     )
+    this.whenUserPluginsReady = this._installUserPlugins().catch((e) => {
+      this.logger.warn('Failed to install some user plugins', e)
+    })
   }
 
   protected async start() {
-    this._installUserPlugins()
+    await this.whenUserPluginsReady
     this._checkAprilFool()
     this._injectPreferenceUI()
   }
@@ -158,9 +162,9 @@ export class PluginPluginStore extends BasePlugin {
     if (!prefs?.length) {
       return
     }
-    for (const pref of prefs) {
-      this.install(pref.registry, pref.id, pref.source, 'user-preference')
-    }
+    await Promise.allSettled(
+      prefs.map((pref) => this.install(pref.registry, pref.id, pref.source, 'user-preference'))
+    )
   }
 
   private async _createManagementApp() {

--- a/packages/core/src/plugins/quick-edit/index.tsx
+++ b/packages/core/src/plugins/quick-edit/index.tsx
@@ -63,7 +63,17 @@ export interface QuickEditSubmitPayload {
   watchlist?: WatchlistAction
 }
 
-@Inject(['api', 'wikiPage', 'wikiTitle', 'currentPage', 'wiki', 'modal', 'preferences', '$'])
+@Inject([
+  'api',
+  'wikiPage',
+  'wikiTitle',
+  'currentPage',
+  'wiki',
+  'modal',
+  'preferences',
+  'store',
+  '$',
+])
 @RegisterPreferences(
   Schema.object({
     'quickEdit.editSummary': Schema.string()
@@ -128,6 +138,11 @@ export class PluginQuickEdit extends BasePlugin {
 
   async showModal(payload?: string | Partial<QuickEditOptions>) {
     const { $ } = this.ctx
+
+    if (this.ctx.store?.whenUserPluginsReady) {
+      await this.ctx.store.whenUserPluginsReady.catch(() => {})
+    }
+
     if (typeof payload === 'undefined') {
       payload = {}
     } else if (typeof payload === 'string') {

--- a/packages/core/src/plugins/quick-edit/index.tsx
+++ b/packages/core/src/plugins/quick-edit/index.tsx
@@ -140,7 +140,7 @@ export class PluginQuickEdit extends BasePlugin {
     const { $ } = this.ctx
 
     if (this.ctx.store?.whenUserPluginsReady) {
-      await this.ctx.store.whenUserPluginsReady.catch(() => {})
+      await this.ctx.store.whenUserPluginsReady
     }
 
     if (typeof payload === 'undefined') {


### PR DESCRIPTION
User plugins from the registry sometimes fail to install before the core plugins have fully loaded, this means that any plugins that modify the core plugins (such as CodeMirror) will fail to load.

A mix of issues contributed to this, one is that `mediawiki.base` isn't reliably available when core plugins are registering. A fix for this was actually already done in #12, however, that one is scoped to in-article-links only, so its fix was moved to `InPageEdit.ts` instead, which means any issues related to this would be gone for all core plugins as well, not just in-article-links.

The other one is obviously that there was no guarantee for the user plugins to settle before any of the core plugins initialized.

https://github.com/user-attachments/assets/7efb66d7-54ed-487c-a275-f4797d43e308

## Summary by Sourcery

确保用户安装的插件在核心插件可用之前已完全安装，并依赖 MediaWiki 基础环境就绪来进行所有核心插件的初始化。

Bug Fixes:
- 保证核心插件初始化会等待用户插件安装完成，从而确保扩展核心插件的用户插件能够可靠加载。
- 确保依赖 MediaWiki hooks 的核心插件只会在 MediaWiki 基础模块加载完成后运行。

Enhancements:
- 并行化核心插件的加载，并通过专用的 readiness promise 跟踪插件商店中用户插件的安装状态。
- 在 MediaWiki 基础就绪状态已由中心统一处理的前提下，简化文章内内容 hook 的注册流程。
- 直接触发 `InPageEdit.ready` MediaWiki hook，而不再使用 ResourceLoader 队列。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure user-installed plugins are fully installed before core plugins become usable and rely on MediaWiki base being ready for all core plugin initialization.

Bug Fixes:
- Guarantee that core plugin initialization awaits completion of user plugin installation so user plugins that extend core plugins load reliably.
- Ensure core plugins depending on MediaWiki hooks only run after the MediaWiki base module is loaded.

Enhancements:
- Parallelize core plugin loading and make plugin-store installation of user plugins tracked via a dedicated readiness promise.
- Simplify in-article content hook registration now that MediaWiki base readiness is handled centrally.
- Trigger the InPageEdit.ready MediaWiki hook directly without using the ResourceLoader queue.

</details>