### PR TITLE
docs(about): Update link to show all contributors

### DIFF
--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -52,7 +52,7 @@ const communityMembers = [
 
 <VPTeamMembers size="small" :members="contributors" />
 
-[查看全部贡献者](https://github.com/inpageedit/inpageedit-next/graphs/contributors)
+[查看全部贡献者](https://github.com/inpageedit/inpageedit-next/graphs/contributors?all=1)
 
 ## 社区成员 Community Members
 


### PR DESCRIPTION
By default, GitHub displays contributors for the last three months rather than 'all'.

## Summary by Sourcery

Documentation:
- 调整“关于”页面上的贡献者链接，以包含所有历史贡献者，而不是默认的最近贡献者子集。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Adjust the contributors link on the about page to include all historical contributors instead of the default recent subset.

</details>